### PR TITLE
Force renewal when SIGHUP is received.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,18 @@ It is assumed that the `tls` volume used to store keys and certificates in
 shared with the HTTP service container, allowing the later to read the files
 upon reception of the signal.
 
+## Forceful renewal
+
+If SIGHUP is sent to acme-buddy, the certificate will be renewed immediately,
+and (if configured) the HTTP service will be reloaded. This is not usually
+necessary as acme-buddy will renew the certificate automatically when needed,
+but can be useful to check that everything is working as expected, including
+certificate reloads.
+
+Note that Let's Encrypt has strict rate limits on the number of certificates
+that can be issued per-domain. Asking acme-buddy to renew the certificate
+repeatedly can quickly hit those limits.
+
 # Testing
 
 The package has both unit and integration tests. They can be run as follows:

--- a/README.md
+++ b/README.md
@@ -153,6 +153,13 @@ necessary as acme-buddy will renew the certificate automatically when needed,
 but can be useful to check that everything is working as expected, including
 certificate reloads.
 
+```sh
+# Start acme-buddy as a named container
+docker run --name acme-buddy ghcr.io/reside-ic/acme-buddy <options...>
+# Force certificate renewal
+docker kill -s SIGHUP acme-buddy
+```
+
 Note that Let's Encrypt has strict rate limits on the number of certificates
 that can be issued per-domain. Asking acme-buddy to renew the certificate
 repeatedly can quickly hit those limits.

--- a/acme.go
+++ b/acme.go
@@ -272,7 +272,6 @@ func (m *certManager) loop(ctx context.Context, initial *x509.Certificate, force
 			case <-forceRenewal:
 				log.Printf("received signal, renewing certificate now")
 			case <-m.after(next.Sub(now)):
-				log.Printf("timeout")
 			}
 		}
 

--- a/acme.go
+++ b/acme.go
@@ -169,9 +169,12 @@ type certManager struct {
 	renewal            time.Duration
 	obtainCertificate  func() (*certificate.Resource, error)
 	installCertificate func(cert *certificate.Resource) error
-	now                func() time.Time
-	sleep              func(time.Duration)
 	noJitter           bool
+
+	// These match the time.Now and time.After functions.
+	// They get mocked during unit tests.
+	now   func() time.Time
+	after func(time.Duration) <-chan time.Time
 }
 
 func (m *certManager) needsRenewal(cert *x509.Certificate) bool {
@@ -238,18 +241,8 @@ func (m *certManager) updateCertificateMetrics(cert *x509.Certificate) {
 	}).Set(1)
 }
 
-func (m *certManager) loop(ctx context.Context, initial *x509.Certificate) {
+func (m *certManager) loop(ctx context.Context, initial *x509.Certificate, forceRenewal <-chan os.Signal) error {
 	labels := prometheus.Labels{"domain": m.domain}
-
-	if initial != nil {
-		m.updateCertificateMetrics(initial)
-	}
-	if initial != nil && !m.needsRenewal(initial) {
-		next := m.nextRenewal(initial)
-		log.Printf("certificate is still valid until %v, next renewal in %v", initial.NotAfter, next.Sub(m.now()))
-		metricNextRenewalTime.With(labels).Set(float64(next.Unix()))
-		m.sleep(next.Sub(m.now()))
-	}
 
 	var b *backoff.Backoff
 	if m.noJitter {
@@ -258,16 +251,41 @@ func (m *certManager) loop(ctx context.Context, initial *x509.Certificate) {
 		b = backoff.New(24*time.Hour, 1*time.Minute)
 	}
 
-	for ctx.Err() == nil {
-		cert, next, err := m.renew()
+	var next time.Time
+	if initial != nil {
+		m.updateCertificateMetrics(initial)
+	}
+	if initial != nil && !m.needsRenewal(initial) {
+		next = m.nextRenewal(initial)
+		log.Printf("certificate is still valid until %v, next renewal in %v", initial.NotAfter, next.Sub(m.now()))
+	}
+
+	for {
+		now := m.now()
+		if next.After(now) {
+			metricNextRenewalTime.With(labels).Set(float64(m.now().Unix()))
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+
+			case <-forceRenewal:
+				log.Printf("received signal, renewing certificate now")
+			case <-m.after(next.Sub(now)):
+				log.Printf("timeout")
+			}
+		}
+
+		var err error
+		var cert *x509.Certificate
+		cert, next, err = m.renew()
 		if err != nil {
 			delay := b.Duration()
 			log.Printf("certificate issuance failed, retrying in %v: %v", delay, err)
 
 			metricLatestRenewalSuccess.With(labels).Set(0)
 			metricLatestRenewalTime.With(labels).Set(float64(m.now().Unix()))
-			metricNextRenewalTime.With(labels).Set(float64(m.now().Add(delay).Unix()))
-			m.sleep(delay)
+			next = m.now().Add(delay)
 		} else {
 			b.Reset()
 			log.Printf("certificate issued, next renewal in %v", next.Sub(m.now()))
@@ -275,11 +293,8 @@ func (m *certManager) loop(ctx context.Context, initial *x509.Certificate) {
 			metricLatestRenewalSuccess.With(labels).Set(1)
 			metricLatestSuccessfulRenewalTime.With(labels).Set(float64(m.now().Unix()))
 			metricLatestRenewalTime.With(labels).Set(float64(m.now().Unix()))
-			metricNextRenewalTime.With(labels).Set(float64(next.Unix()))
 
 			m.updateCertificateMetrics(cert)
-
-			m.sleep(next.Sub(m.now()))
 		}
 	}
 }
@@ -290,7 +305,8 @@ func NewCertManager(client *lego.Client, renewal time.Duration, domain string, i
 		renewal:            renewal,
 		obtainCertificate:  func() (*certificate.Resource, error) { return ObtainCertificate(client, domain) },
 		installCertificate: installCertificate,
-		now:                time.Now,
-		sleep:              time.Sleep,
+
+		now:   time.Now,
+		after: time.After,
 	}
 }

--- a/acme_test.go
+++ b/acme_test.go
@@ -8,6 +8,8 @@ import (
 	"encoding/pem"
 	"errors"
 	"math/big"
+	"os"
+	"syscall"
 	"testing"
 	"time"
 
@@ -57,10 +59,15 @@ func createTestCertificate(notAfter time.Time) (*certificate.Resource, *x509.Cer
 	}, cert
 }
 
+type wakeup struct {
+	time time.Time
+	ch   chan<- time.Time
+}
+
 type callbacks struct {
 	mock.Mock
 	time time.Time
-	ch   chan struct{}
+	ch   chan wakeup
 }
 
 func (c *callbacks) obtainCertificate() (*certificate.Resource, error) {
@@ -78,37 +85,38 @@ func (c *callbacks) installCertificate(cert *certificate.Resource) error {
 func (c *callbacks) now() time.Time {
 	return c.time
 }
-func (c *callbacks) sleep(t time.Duration) {
-	c.time = c.time.Add(t)
+func (c *callbacks) after(t time.Duration) <-chan time.Time {
 	c.Called(t)
 
-	// Write to the channel twice - first time lets the barrier() function
-	// known we've reached this point, second write is barrier() letting us
-	// proceed.
-	<-c.ch
-	<-c.ch
+	result := make(chan time.Time, 1)
+	c.ch <- wakeup{c.time.Add(t), result}
+
+	return result
 }
 
-// Used by test code to synchronize with calls to `sleep()`. Calls to sleep
-// block until `barrier` is called.  The `f` callback is invoked while `sleep`
-// is still blocked, and when the callback returns `sleep()` is released.
-func (c *callbacks) barrier(f func()) {
-	c.ch <- struct{}{}
-	f()
-	c.ch <- struct{}{}
+// Used by test code to synchronize with calls to `after()`. When `after()` is
+// called, the callback `f` will be executed. The channel returned by `after()`
+// is only written to once `f()` returns - if it returns true. If `f()` returns
+// false, the channel returned by `after()` never resolves.
+func (c *callbacks) barrier(f func() bool) {
+	w := <-c.ch
+	c.time = w.time
+	if f() {
+		w.ch <- c.time
+	}
 }
 
 func newTestCertManager(renewal time.Duration) (*certManager, *callbacks) {
 	callbacks := &callbacks{
 		time: time.Now().Round(time.Second),
-		ch:   make(chan struct{}),
+		ch:   make(chan wakeup),
 	}
 
 	m := &certManager{
 		obtainCertificate:  callbacks.obtainCertificate,
 		installCertificate: callbacks.installCertificate,
 		now:                callbacks.now,
-		sleep:              callbacks.sleep,
+		after:              callbacks.after,
 		renewal:            renewal,
 		noJitter:           true,
 	}
@@ -126,39 +134,44 @@ func TestCertificateIsObtainedImmediately(t *testing.T) {
 	mock.InOrder(
 		callbacks.On("obtainCertificate").Return(cert, nil).Once(),
 		callbacks.On("installCertificate", cert).Return(nil).Once(),
-		callbacks.On("sleep", 120*time.Minute).Return().Once(),
+		callbacks.On("after", 120*time.Minute).Return().Once(),
 	)
 
-	go m.loop(ctx, nil)
+	go m.loop(ctx, nil, nil)
 
-	callbacks.barrier(func() {
+	callbacks.barrier(func() bool {
 		callbacks.AssertExpectations(t)
+		return false
 	})
 }
 
 func TestSleepsUntilCertificateExpiry(t *testing.T) {
 	ctx := testContext(t)
 	m, callbacks := newTestCertManager(60 * time.Minute)
-	callbacks.On("sleep", 120*time.Minute).Return().Once()
+	callbacks.On("after", 120*time.Minute).Return().Once()
 
 	_, cert := createTestCertificate(callbacks.time.Add(180 * time.Minute))
 
-	go m.loop(ctx, cert)
+	go m.loop(ctx, cert, nil)
 
-	callbacks.barrier(func() {
+	callbacks.barrier(func() bool {
 		callbacks.AssertExpectations(t)
-		callbacks.On("sleep", mock.Anything).Unset()
+		callbacks.On("after", mock.Anything).Unset()
 
 		renewedCert, _ := createTestCertificate(callbacks.time.Add(240 * time.Minute))
 		mock.InOrder(
 			callbacks.On("obtainCertificate").Return(renewedCert, nil).Once(),
 			callbacks.On("installCertificate", renewedCert).Return(nil).Once(),
-			callbacks.On("sleep", 180*time.Minute).Return().Once(),
+			callbacks.On("after", 180*time.Minute).Return().Once(),
 		)
+
+		return true
 	})
 
-	callbacks.barrier(func() {
+	callbacks.barrier(func() bool {
 		callbacks.AssertExpectations(t)
+
+		return false
 	})
 }
 
@@ -169,63 +182,102 @@ func TestIssuanceIsRetriedOnError(t *testing.T) {
 
 	m, callbacks := newTestCertManager(60 * time.Minute)
 	callbacks.On("obtainCertificate").Return(nil, errors.New("failed"))
-	callbacks.On("sleep", 1*time.Minute)
+	callbacks.On("after", 1*time.Minute)
 
-	go m.loop(ctx, nil)
+	go m.loop(ctx, nil, nil)
 
-	callbacks.barrier(func() {
+	callbacks.barrier(func() bool {
 		callbacks.AssertExpectations(t)
 
-		callbacks.On("sleep", mock.Anything).Unset()
-		callbacks.On("sleep", 2*time.Minute)
+		callbacks.On("after", mock.Anything).Unset()
+		callbacks.On("after", 2*time.Minute)
+		return true
 	})
 
-	callbacks.barrier(func() {
+	callbacks.barrier(func() bool {
 		callbacks.AssertExpectations(t)
 
 		callbacks.On("obtainCertificate", mock.Anything).Unset()
-		callbacks.On("sleep", mock.Anything).Unset()
+		callbacks.On("after", mock.Anything).Unset()
 
 		// Errors on installCertificate also get retried.
 		cert, _ := createTestCertificate(callbacks.time.Add(180 * time.Minute))
 		mock.InOrder(
 			callbacks.On("obtainCertificate").Return(cert, nil),
 			callbacks.On("installCertificate", cert).Return(errors.New("failure")),
-			callbacks.On("sleep", 4*time.Minute),
+			callbacks.On("after", 4*time.Minute),
 		)
+		return true
 	})
 
-	callbacks.barrier(func() {
+	callbacks.barrier(func() bool {
 		callbacks.AssertExpectations(t)
 
 		callbacks.On("obtainCertificate", mock.Anything).Unset()
 		callbacks.On("installCertificate", mock.Anything).Unset()
-		callbacks.On("sleep", mock.Anything).Unset()
+		callbacks.On("after", mock.Anything).Unset()
 
 		// Allow the issuance to succeed. Manager will sleep until expiry.
 		cert, _ := createTestCertificate(callbacks.time.Add(120 * time.Minute))
 		mock.InOrder(
 			callbacks.On("obtainCertificate").Return(cert, nil),
 			callbacks.On("installCertificate", cert).Return(nil),
-			callbacks.On("sleep", 60*time.Minute).Return(),
+			callbacks.On("after", 60*time.Minute).Return(),
 		)
+
+		return true
 	})
 
-	callbacks.barrier(func() {
+	callbacks.barrier(func() bool {
 		callbacks.AssertExpectations(t)
 
 		callbacks.On("obtainCertificate", mock.Anything).Unset()
 		callbacks.On("installCertificate", mock.Anything).Unset()
-		callbacks.On("sleep", mock.Anything).Unset()
+		callbacks.On("after", mock.Anything).Unset()
 
 		// Renewal fails again - the exponential backoff is reset.
 		mock.InOrder(
 			callbacks.On("obtainCertificate").Return(nil, errors.New("failed")),
-			callbacks.On("sleep", 1*time.Minute).Return(),
+			callbacks.On("after", 1*time.Minute).Return(),
 		)
+
+		return true
 	})
 
-	callbacks.barrier(func() {
+	callbacks.barrier(func() bool {
 		callbacks.AssertExpectations(t)
+
+		return false
+	})
+}
+
+func TestCanForceRenewalWithSignal(t *testing.T) {
+	ctx := testContext(t)
+
+	m, callbacks := newTestCertManager(60 * time.Minute)
+	callbacks.On("after", 120*time.Minute).Return().Once()
+
+	_, cert := createTestCertificate(callbacks.time.Add(180 * time.Minute))
+	forceRenewal := make(chan os.Signal, 1)
+	go m.loop(ctx, cert, forceRenewal)
+
+	callbacks.barrier(func() bool {
+		callbacks.AssertExpectations(t)
+		cert, _ := createTestCertificate(callbacks.time.Add(120 * time.Minute))
+		mock.InOrder(
+			callbacks.On("obtainCertificate").Return(cert, nil).Once(),
+			callbacks.On("installCertificate", cert).Return(nil).Once(),
+			callbacks.On("after", 60*time.Minute).Return(),
+		)
+
+		// return false means the sleep never completes - instead the signal is
+		// what triggers renewal
+		forceRenewal <- syscall.SIGHUP
+		return false
+	})
+
+	callbacks.barrier(func() bool {
+		callbacks.AssertExpectations(t)
+		return false
 	})
 }

--- a/main.go
+++ b/main.go
@@ -7,8 +7,10 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"slices"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/docker/docker/client"
@@ -143,6 +145,10 @@ func main() {
 	} else {
 		http.Handle("/metrics", promhttp.Handler())
 		go http.ListenAndServe(*metricsFlag, nil)
-		m.loop(context.Background(), cert)
+
+		renewSignal := make(chan os.Signal)
+		signal.Notify(renewSignal, syscall.SIGHUP)
+
+		m.loop(context.Background(), cert, renewSignal)
 	}
 }


### PR DESCRIPTION
This is not usually needed since renewals happen automatically, but it can be handy to check that everything has been wired up properly.