### PR TITLE
Add the latest tag to images built from main.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,6 +25,11 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            # Set the latest tag for pushes to the main branch only
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Log in to the Container registry
         uses: docker/login-action@v3


### PR DESCRIPTION
I thought this would happen automatically, but it turns out by default it is only done for Git tags. See the [`docker/metadata-action`][metadata-action] docs for details on this.

The rest of the tags spec is there to retain the default behaviour of creating tags based on branch names and PR numbers.

[metadata-action]: https://github.com/docker/metadata-action/blob/b798ed8388581f6f002541048b6458ca2c4ba442/README.md#latest-tag