### PR TITLE
Allow comma-separated domains, keys and certs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@ used to register `<FQDN>`.
 
 Usually `<FQDN>` is a single domain; if you would like multiple 
 subjectAlternativeNames (SANs) in the certificate, then include a 
-comma-separated string of domain names here. The first of these is
-assumed to be the most significant, and will be the one used when reporting
-metrics - see below.
+comma-separated string of domain names here. The first of these will be
+the one used when reporting metrics - see below.
 
 ```sh
 docker run \

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ The most basic usage is show below. `<FQDN>` and `<PROVIDER>` should be
 replaced by their appropriate values. The provider should match the service
 used to register `<FQDN>`.
 
+Usually `<FQDN>` is a single domain; if you would like multiple 
+subjectAlternativeNames (SANs) in the certificate, then include a 
+comma-separated string of domain names here. The first of these is
+assumed to be the most significant, and will be the one used when reporting
+metrics - see below.
+
 ```sh
 docker run \
     --env-file credentials \

--- a/acme.go
+++ b/acme.go
@@ -96,9 +96,9 @@ func RegisterAccount(client *lego.Client, account *Account) error {
 	return nil
 }
 
-func ObtainCertificate(client *lego.Client, domain string) (*certificate.Resource, error) {
+func ObtainCertificate(client *lego.Client, domains []string) (*certificate.Resource, error) {
 	request := certificate.ObtainRequest{
-		Domains: []string{domain},
+		Domains: domains,
 		Bundle:  true,
 	}
 
@@ -165,7 +165,7 @@ func createClient(server, email, accountPath string, opts []dns01.ChallengeOptio
 }
 
 type certManager struct {
-	domain             string
+	domains            []string
 	renewal            time.Duration
 	obtainCertificate  func() (*certificate.Resource, error)
 	installCertificate func(cert *certificate.Resource) error
@@ -217,7 +217,7 @@ func (m *certManager) renew() (*x509.Certificate, time.Time, error) {
 func (m *certManager) updateCertificateMetrics(cert *x509.Certificate) {
 	fingerprint := sha256.Sum256(cert.Raw)
 
-	metricCertificateExpiry.WithLabelValues(m.domain).Set(float64(cert.NotAfter.Unix()))
+	metricCertificateExpiry.WithLabelValues(m.domains[0]).Set(float64(cert.NotAfter.Unix()))
 
 	// This metric is designed to match the blackbox_exporter's metric:
 	// https://github.com/prometheus/blackbox_exporter/blob/f77c50ed7c0f39b734235931e773cf7b5af1fc8a/prober/tls.go
@@ -232,7 +232,7 @@ func (m *certManager) updateCertificateMetrics(cert *x509.Certificate) {
 	// what the current certificate info is, hence the `Reset()` call.
 	metricCertificateInfo.Reset()
 	metricCertificateInfo.With(prometheus.Labels{
-		"domain":             m.domain,
+		"domain":             m.domains[0],
 		"fingerprint_sha256": hex.EncodeToString(fingerprint[:]),
 		"subject":            cert.Subject.String(),
 		"issuer":             cert.Issuer.String(),
@@ -242,7 +242,7 @@ func (m *certManager) updateCertificateMetrics(cert *x509.Certificate) {
 }
 
 func (m *certManager) loop(ctx context.Context, initial *x509.Certificate, forceRenewal <-chan os.Signal) error {
-	labels := prometheus.Labels{"domain": m.domain}
+	labels := prometheus.Labels{"domain": m.domains[0]}
 
 	var b *backoff.Backoff
 	if m.noJitter {
@@ -298,9 +298,9 @@ func (m *certManager) loop(ctx context.Context, initial *x509.Certificate, force
 	}
 }
 
-func NewCertManager(client *lego.Client, renewal time.Duration, domain string, installCertificate func(cert *certificate.Resource) error) *certManager {
+func NewCertManager(client *lego.Client, renewal time.Duration, domains []string, installCertificate func(cert *certificate.Resource) error) *certManager {
 	return &certManager{
-		domain:             domain,
+		domains:             domains,
 		renewal:            renewal,
 		obtainCertificate:  func() (*certificate.Resource, error) { return ObtainCertificate(client, domain) },
 		installCertificate: installCertificate,

--- a/acme.go
+++ b/acme.go
@@ -302,7 +302,7 @@ func NewCertManager(client *lego.Client, renewal time.Duration, domains []string
 	return &certManager{
 		domains:             domains,
 		renewal:            renewal,
-		obtainCertificate:  func() (*certificate.Resource, error) { return ObtainCertificate(client, domain) },
+		obtainCertificate:  func() (*certificate.Resource, error) { return ObtainCertificate(client, domains) },
 		installCertificate: installCertificate,
 
 		now:   time.Now,

--- a/acme_test.go
+++ b/acme_test.go
@@ -113,6 +113,7 @@ func newTestCertManager(renewal time.Duration) (*certManager, *callbacks) {
 	}
 
 	m := &certManager{
+		domains:            []string{"example.com"}
 		obtainCertificate:  callbacks.obtainCertificate,
 		installCertificate: callbacks.installCertificate,
 		now:                callbacks.now,

--- a/acme_test.go
+++ b/acme_test.go
@@ -113,7 +113,7 @@ func newTestCertManager(renewal time.Duration) (*certManager, *callbacks) {
 	}
 
 	m := &certManager{
-		domains:            []string{"example.com"}
+		domains:            []string{"example.com"},
 		obtainCertificate:  callbacks.obtainCertificate,
 		installCertificate: callbacks.installCertificate,
 		now:                callbacks.now,

--- a/main.go
+++ b/main.go
@@ -92,11 +92,6 @@ func installCertificate(cert *certificate.Resource) error {
 func main() {
 	flag.Parse()
 
-	domains := strings.Split(*domainFlag, ",")
-	for i := range domains {
-		domains[i] = strings.TrimSpace(domains[i])
-	}
-
 	server := *serverFlag
 	if server == "" {
 		if *stagingFlag {
@@ -112,7 +107,10 @@ func main() {
 		log.Fatal("--domain and --email must be set")
 	}
 	
-	
+	domains := strings.Split(*domainFlag, ",")
+	for i := range domains {
+		domains[i] = strings.TrimSpace(domains[i])
+	}
 
 	// Checking propagation of DNS records won't work during integration tests.
 	// The flag allows us to skip that.

--- a/main.go
+++ b/main.go
@@ -134,7 +134,7 @@ func main() {
 		log.Fatal("Inconsistent numbers of domains, certs, or keys specified.")
 	}	
 
-	var managers []*CertManager
+	var managers []*NewCertManager
 	var certs []*x509.Certificate
 
 	for i := 0; i < len(splitDomains); i++ {
@@ -179,8 +179,7 @@ func main() {
 		}
 	} else {
 		for i, m := range managers {
-			cert := certs[i]
-			go m.loop(context.Background(), cert, renewSignal)
+			go m.loop(context.Background(), certs[i], renewSignal)
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -137,7 +137,7 @@ func main() {
 	var managers []*CertManager
 	var certs []*x509.Certificate
 
-	for i := 0; i < len(splitDomains); i++) {
+	for i := 0; i < len(splitDomains); i++ {
 		*domainFlag = strings.TrimSpace(splitDomains[i])
 		*certificatePathFlag = strings.TrimSpace(splitCertPaths[i])
 		*keyPathFlag = strings.TrimSpace(splitKeyPaths[i])

--- a/main.go
+++ b/main.go
@@ -181,5 +181,6 @@ func main() {
 		for i, m := range managers {
 			go m.loop(context.Background(), certs[i], renewSignal)
 		}
+		select {}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -134,7 +134,7 @@ func main() {
 		log.Fatal("Inconsistent numbers of domains, certs, or keys specified.")
 	}	
 
-	var managers []*NewCertManager
+	var managers []*certManager
 	var certs []*x509.Certificate
 
 	for i := 0; i < len(splitDomains); i++ {


### PR DESCRIPTION
This would allow us, for example, to request letsencrypt certs for...
shiny.dide.ic.ac.uk
shiny.epidemiology.net

pointing to the same place. This would require similarly multiple locations for the cert and key (which would then have to match the apache virtualhosts specs for where the certs are expected to be).